### PR TITLE
Tabulate: correct alignment when missingval contains a color code

### DIFF
--- a/pgcli/packages/tabulate.py
+++ b/pgcli/packages/tabulate.py
@@ -889,7 +889,8 @@ def tabulate(tabular_data, headers=[], tablefmt="simple",
     _text_type_encode = lambda x: _text_type(utf8tounicode(x))
     plain_text = '\n'.join(['\t'.join(map(_text_type_encode, headers))] + \
                             ['\t'.join(map(_text_type_encode, row)) for row in list_of_lists])
-    has_invisible = re.search(_invisible_codes, plain_text)
+    has_invisible = (re.search(_invisible_codes, plain_text) or
+      re.search(_invisible_codes, missingval))
     if has_invisible:
         width_fn = _visible_width
     else:


### PR DESCRIPTION
I think this fix belongs in your PR. It will allow us to use e.g. `null_string = [35mNULL[0m`.

![screen shot 0028-07-29 at 17 28 05](https://cloud.githubusercontent.com/assets/18589234/17253645/ec447808-55b1-11e6-9b2b-acdba453bebc.png)
